### PR TITLE
Control math

### DIFF
--- a/firmware/ga2o3-ws/.theia/launch.json
+++ b/firmware/ga2o3-ws/.theia/launch.json
@@ -29,15 +29,6 @@
             }
         },
         {
-            "name": "epwm_ex8_deadband",
-            "type": "ccs-debug",
-            "request": "launch",
-            "projectInfo": {
-                "name": "ga2o3-apd",
-                "resourceId": "/ga2o3-apd"
-            }
-        },
-        {
             "name": "sci_ex2_loopback_interrupts",
             "type": "ccs-debug",
             "request": "launch",

--- a/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Inc/board_test.h
+++ b/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Inc/board_test.h
@@ -13,10 +13,24 @@
 #include "bsp_adc.h"
 #include "adc_config.h"
 
+#define GD_EN       25 
+#define GD_HS_PWM1  1  
+#define GD_LS_PWM1  0
+#define GD_HS_PWM2  3  
+#define GD_LS_PWM2  2
+#define GD_HS_PWM3  5
+#define GD_LS_PWM3  4
+
+#define GD_FLT1     66
+#define GD_FLT2     131
+#define GD_FLT3     130
+
+#define BLINKY_LED_GPIO    10
 
 
+void InitGateDriverTest(void);
+void EnableGateDriver(void);
 
-void EnableGateDriver();
 
 void EnableVoltageSen();
 

--- a/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Inc/board_test.h
+++ b/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Inc/board_test.h
@@ -1,0 +1,24 @@
+/**
+ * @file board_test.h
+ * @author Arnold
+ * @brief Enable Different Functions of the system to test
+ * @version 1.0
+ * @date 2026-04-06
+ *
+ * @copyright Copyright (c) 2026
+ *
+ */
+
+
+#include "bsp_adc.h"
+#include "adc_config.h"
+
+
+
+
+void EnableGateDriver();
+
+void EnableVoltageSen();
+
+void EnableCurrentSen();
+

--- a/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Inc/control.h
+++ b/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Inc/control.h
@@ -1,127 +1,190 @@
 /**
  * @file control.h
- * @author lan
+ * @author Arnold
  * @brief implement control task
- * @version 0.1
- * @date 2026-03-09
- * 
+ * @version 1.0
+ * @date 2026-04-06
+ *
  * @copyright Copyright (c) 2026
- * 
+ *
  */
 #ifndef __CONTROL_H__
 #define __CONTROL_H__
 
+#include <math.h>
+
+#define PI     3.14159265358979f    // pi constant for angle calculations
+#define TWO_PI 6.28318530717959f    // 2*pi used for angle wrapping (0 to 2pi)
+/* -----------------------------------------------------------------------
+ * Structs
+ * -------------------------------------------------------------------- */
 
 typedef struct
 {
     float error;
     float set_point;
     float sampling_time;
-
     float kp;
-
-    float integral;
     float ki;
+    float integral;
     float min_integral;
-}pid ;
-
+    float max_integral;
+    float output;
+} PidTypeDef;
 
 typedef struct
 {
     float r;
     float theta;
- }polar ;
-
-
- typedef struct
- {
-    float x;
-    float y;
- }cart ;
-
-
- typedef struct
- {
-    float alpha;
-    float beta;
- }alphbeta ;
-
- typedef struct
- {
-    float d;
-    float q;
- }dq ;
+} PolarTypeDef;
 
 typedef struct
 {
-    float input;
-    float err;
+    float x;
+    float y;
+} CartTypeDef;
+
+typedef struct
+{
     float alpha;
-    float product_alpha_omega;
+    float beta;
+} AlphabetaTypeDef;
+
+typedef struct
+{
+    float d;
+    float q;
+} DqTypeDef;
+
+typedef struct
+{
+    float alpha;
     float beta;
     float k;
     float sampling_time;
-}sogi ;
+} SogiTypeDef;
 
 typedef struct
 {
-int freq;
-float sampling_time;
-float theta;
-float omega;
-
-}angelgen ;
-
+    int   freq;
+    float sampling_time;
+    float theta;
+    float omega;
+} AngleGenTypeDef;
 
 
-
-
-
-/**
- * @brief Initialize control related things
- * 
- * @return none
- */
-void InitPIDControl();
+/* -----------------------------------------------------------------------
+ * PID
+ * -------------------------------------------------------------------- */
 
 /**
- * @brief The main control task, better put it into an interrupt
- * 
- * @return none
+ * @brief Initialize PID controller to zero and set gains
+ *
+ * @param [in,out] pid_var        PID struct to initialize
+ * @param [in]     set_point      target reference value
+ * @param [in]     kp             proportional gain
+ * @param [in]     ki             integral gain
+ * @param [in]     limit          integral clamp value, applied as +/- limit
+ * @param [in]     sampling_time  loop period in seconds
  */
-float PIDControl(float measured_value, float set_point, float sampling_time);
-
-
+void InitPidControl(PidTypeDef *pid_var, float set_point, float kp,
+                    float ki, float limit, float sampling_time);
 
 /**
- * @brief The main control task, better put it into an interrupt
- * 
- * @return none
+ * @brief Run one PID cycle, call at fixed sampling_time interval
+ *
+ * @param [in,out] pid_var          PID struct
+ * @param [in]     measured_value   current process measurement
  */
- cart PolartoCartesian();
+void RunPidControl(PidTypeDef *pid_var, float measured_value);
 
+
+/* -----------------------------------------------------------------------
+ * Coordinate transforms
+ * -------------------------------------------------------------------- */
 
 /**
- * @brief The main control task, better put it into an interrupt
- * 
- * @return none
+ * @brief Convert polar coordinates to cartesian
+ *
+ * @param [in] p    polar input (r, theta)
+ * @return          cartesian output (x, y)
  */
-polar CartesiantoPolar(cart c);
-
+CartTypeDef ConvertPolarToCartesian(PolarTypeDef p);
 
 /**
- * @brief The main control task, better put it into an interrupt
- * 
- * @return none
+ * @brief Convert cartesian coordinates to polar
+ *
+ * @param [in] c    cartesian input (x, y)
+ * @return          polar output (r, theta)
  */
- dq AlphabetaToDq(alphbeta alphabetavar);
+PolarTypeDef ConvertCartesianToPolar(CartTypeDef c);
+
+
+/* -----------------------------------------------------------------------
+ * Frame transforms
+ * -------------------------------------------------------------------- */
 
 /**
- * @brief The main control task, better put it into an interrupt
- * 
- * @return none
+ * @brief Park transform — stationary alphabeta frame to rotating dq frame
+ *
+ * @param [in] alphabeta_var    alphabeta frame input
+ * @param [in] theta            rotor electrical angle in radians
+ * @return                      dq frame output
  */
- alphabeta DqToAlphabeta(dq dqvar);
+DqTypeDef ConvertAlphabetaToDq(AlphabetaTypeDef alphabeta_var, float theta);
+
+/**
+ * @brief Inverse Park transform — rotating dq frame to stationary alphabeta frame
+ *
+ * @param [in] dq_var   dq frame input
+ * @param [in] theta    rotor electrical angle in radians
+ * @return              alphabeta frame output
+ */
+AlphabetaTypeDef ConvertDqToAlphabeta(DqTypeDef dq_var, float theta);
 
 
-#endif
+/* -----------------------------------------------------------------------
+ * SOGI
+ * -------------------------------------------------------------------- */
+
+/**
+ * @brief Initialize SOGI struct
+ *
+ * @param [in,out] sogi_var      SOGI struct to initialize
+ * @param [in]     gain          damping gain k, typically sqrt(2) = 1.414
+ * @param [in]     sampling_time loop period in seconds
+ */
+void InitSogi(SogiTypeDef *sogi_var, float gain, float sampling_time);
+
+/**
+ * @brief Run one SOGI cycle, generates quadrature alpha and beta signals
+ *
+ * @param [in,out] sogi_var  SOGI struct
+ * @param [in]     input     single phase AC input sample
+ * @param [in]     omega     angular frequency in rad/s
+ */
+void RunSogi(SogiTypeDef *sogi_var, float input, float omega);
+
+
+/* -----------------------------------------------------------------------
+ * Angle generation
+ * -------------------------------------------------------------------- */
+
+/**
+ * @brief Initialize angle generator
+ *
+ * @param [in,out] ag_var        angle generator struct to initialize
+ * @param [in]     freq          fixed frequency in Hz
+ * @param [in]     sampling_time loop period in seconds
+ */
+void InitAngleGen(AngleGenTypeDef *ag_var, int freq, float sampling_time);
+
+/**
+ * @brief Run one angle generation cycle, integrates omega to produce theta
+ *
+ * @param [in,out] ag_var    angle generator struct
+ */
+void GenerateAngle(AngleGenTypeDef *ag_var);
+
+
+#endif /* __CONTROL_H__ */

--- a/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Inc/control.h
+++ b/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Inc/control.h
@@ -11,19 +11,117 @@
 #ifndef __CONTROL_H__
 #define __CONTROL_H__
 
+
+typedef struct
+{
+    float error;
+    float set_point;
+    float sampling_time;
+
+    float kp;
+
+    float integral;
+    float ki;
+    float min_integral;
+}pid ;
+
+
+typedef struct
+{
+    float r;
+    float theta;
+ }polar ;
+
+
+ typedef struct
+ {
+    float x;
+    float y;
+ }cart ;
+
+
+ typedef struct
+ {
+    float alpha;
+    float beta;
+ }alphbeta ;
+
+ typedef struct
+ {
+    float d;
+    float q;
+ }dq ;
+
+typedef struct
+{
+    float input;
+    float err;
+    float alpha;
+    float product_alpha_omega;
+    float beta;
+    float k;
+    float sampling_time;
+}sogi ;
+
+typedef struct
+{
+int freq;
+float sampling_time;
+float theta;
+float omega;
+
+}angelgen ;
+
+
+
+
+
+
 /**
  * @brief Initialize control related things
  * 
  * @return none
  */
-void InitControl(void);
+void InitPIDControl();
 
 /**
  * @brief The main control task, better put it into an interrupt
  * 
  * @return none
  */
-void TaskControl(void);
+float PIDControl(float measured_value, float set_point, float sampling_time);
+
+
+
+/**
+ * @brief The main control task, better put it into an interrupt
+ * 
+ * @return none
+ */
+ cart PolartoCartesian();
+
+
+/**
+ * @brief The main control task, better put it into an interrupt
+ * 
+ * @return none
+ */
+polar CartesiantoPolar(cart c);
+
+
+/**
+ * @brief The main control task, better put it into an interrupt
+ * 
+ * @return none
+ */
+ dq AlphabetaToDq(alphbeta alphabetavar);
+
+/**
+ * @brief The main control task, better put it into an interrupt
+ * 
+ * @return none
+ */
+ alphabeta DqToAlphabeta(dq dqvar);
 
 
 #endif

--- a/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Inc/control_math.h
+++ b/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Inc/control_math.h
@@ -1,5 +1,5 @@
 /**
- * @file control.h
+ * @file control_math.h
  * @author Arnold
  * @brief implement control task
  * @version 1.0
@@ -27,10 +27,9 @@ typedef struct
     float kp;
     float ki;
     float integral;
-    float min_integral;
-    float max_integral;
+    float limit;
     float output;
-} PidTypeDef;
+} PiTypeDef;
 
 typedef struct
 {
@@ -48,7 +47,7 @@ typedef struct
 {
     float alpha;
     float beta;
-} AlphabetaTypeDef;
+} AlphaBetaTypeDef;
 
 typedef struct
 {
@@ -81,22 +80,21 @@ typedef struct
  * @brief Initialize PID controller to zero and set gains
  *
  * @param [in,out] pid_var        PID struct to initialize
- * @param [in]     set_point      target reference value
  * @param [in]     kp             proportional gain
  * @param [in]     ki             integral gain
  * @param [in]     limit          integral clamp value, applied as +/- limit
  * @param [in]     sampling_time  loop period in seconds
  */
-void InitPidControl(PidTypeDef *pid_var, float set_point, float kp,
-                    float ki, float limit, float sampling_time);
+void InitPiControl(PiTypeDef *pid_var, float kp, float ki, float limit, float sampling_time);
 
 /**
  * @brief Run one PID cycle, call at fixed sampling_time interval
  *
  * @param [in,out] pid_var          PID struct
+ * @param [in]     set_point        target reference value
  * @param [in]     measured_value   current process measurement
  */
-void RunPidControl(PidTypeDef *pid_var, float measured_value);
+void RunPiControl(PiTypeDef *pid_var, float set_point, float measured_value);
 
 
 /* -----------------------------------------------------------------------
@@ -109,7 +107,7 @@ void RunPidControl(PidTypeDef *pid_var, float measured_value);
  * @param [in] p    polar input (r, theta)
  * @return          cartesian output (x, y)
  */
-CartTypeDef ConvertPolarToCartesian(PolarTypeDef p);
+CartTypeDef PolarToCartesian(PolarTypeDef p);
 
 /**
  * @brief Convert cartesian coordinates to polar
@@ -117,7 +115,7 @@ CartTypeDef ConvertPolarToCartesian(PolarTypeDef p);
  * @param [in] c    cartesian input (x, y)
  * @return          polar output (r, theta)
  */
-PolarTypeDef ConvertCartesianToPolar(CartTypeDef c);
+PolarTypeDef CartesianToPolar(CartTypeDef c);
 
 
 /* -----------------------------------------------------------------------
@@ -131,7 +129,7 @@ PolarTypeDef ConvertCartesianToPolar(CartTypeDef c);
  * @param [in] theta            rotor electrical angle in radians
  * @return                      dq frame output
  */
-DqTypeDef ConvertAlphabetaToDq(AlphabetaTypeDef alphabeta_var, float theta);
+DqTypeDef ConvertAlphabetaToDq(AlphaBetaTypeDef alphabeta_var, float theta);
 
 /**
  * @brief Inverse Park transform — rotating dq frame to stationary alphabeta frame
@@ -140,7 +138,7 @@ DqTypeDef ConvertAlphabetaToDq(AlphabetaTypeDef alphabeta_var, float theta);
  * @param [in] theta    rotor electrical angle in radians
  * @return              alphabeta frame output
  */
-AlphabetaTypeDef ConvertDqToAlphabeta(DqTypeDef dq_var, float theta);
+AlphaBetaTypeDef ConvertDqToAlphabeta(DqTypeDef dq_var, float theta);
 
 
 /* -----------------------------------------------------------------------

--- a/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Inc/global_defines.h
+++ b/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Inc/global_defines.h
@@ -18,10 +18,25 @@ extern "C"
 
 #include "device.h"
 
-#define PARAMS_SYS_CLOCK                (DEVICE_SYSCLK_FREQ)
+#define PARAMS_SYS_CLOCK                    (DEVICE_SYSCLK_FREQ)
 #define PARAMS_SCHEDULER_MAX_TASKS_LIMIT    (32) //max 32 tasks are allowed
 
-#define PI2 (3.1415926535 * 2)
+#define PI2                                 (3.1415926535 * 2)
+#define TS_US                               (200)
+#define CURRENT_FB_GAIN                     (-1)
+#define FSW                                 (10000)
+#define DEATTIME_US                         (1)
+#define TR                                  (0.005)
+#define L1_UH                               (3000)
+#define R1_OHM                              (0.05)
+#define VDC                                 (400)
+#define AC_FREQ                             (50)
+#define SOGI_GAIN                           (1)
+#define ID_REF_AMPS                         (0)
+#define IQ_REF_AMPS                         (5)
+
+#define MAX_PHASE_CURRENT_AMPS              (20)
+
 
 #ifdef __cplusplus
 }

--- a/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Inc/state_machine.h
+++ b/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Inc/state_machine.h
@@ -15,15 +15,47 @@ extern "C"
 #endif
 
 #include "main.h"
+#include "control_math.h"
 
 typedef enum
 {
     STATE_INIT = 0,
     STATE_IDLE,
     STATE_RUNNING,
+    STATE_DISCHARGING,
+    STATE_STOP,
     STATE_ERROR,
+    STATE_OVER_CURRENT,
 } StateMachineTypeDef;
 
+typedef struct
+{
+    uint16_t interleaved_mode_switch; //0 => non-interleaved, else interleaved
+    uint16_t output_enabled; //0 => disabled, else enabled
+    uint16_t current_control_enabled; //0 => disabled, else enabled
+    uint16_t reset;//if reset != 0 detected(modified by MCUViewer), do reset and restart
+    float32_t ts_us;
+    float32_t current_feedback_amps;
+    float32_t k_current_feedback;
+    float32_t omega_rad;
+    AlphaBetaTypeDef current_ab_amps;
+    AlphaBetaTypeDef output_ab;
+    float32_t sin_omega;
+    float32_t cos_omega;
+    float32_t output_duty;
+    SogiTypeDef current_sogi;
+    DqTypeDef idq_meas_amps;
+    DqTypeDef idq_ref_amps;
+    DqTypeDef idq_output_amps;
+    AngleGenTypeDef angle_generation;
+    PiTypeDef pi_id;
+    PiTypeDef pi_iq;
+    PolarTypeDef pi_output_polar;
+    CartTypeDef pi_output_cart;
+
+} ControlParamsTypeDef;
+
+extern ControlParamsTypeDef control_params;
 
 /**
  * @brief Initialize the state machine
@@ -38,6 +70,13 @@ void InitStateMachine(void);
  *@return none
  */
 void TaskStateMachine(void);
+
+void SetIdRef(float32_t ref);
+void SetIqRef(float32_t ref);
+void SetOpenLoopVoltage(float32_t voltage_rms, float32_t freq);
+void EnableCurrentContrl(void);
+void EnableCurrentContrl(void);
+
 
 #ifdef __cplusplus
 }

--- a/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Src/board_test.c
+++ b/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Src/board_test.c
@@ -1,5 +1,54 @@
 #include <stdio.h>
 #include "adc_config.h"
+#include "board_test.h"
+#include "gpio.h"
+
+int GD_EN_VAL =1;
+
+void InitGateDriverTest()
+{
+    GPIO_setPadConfig(BLINKY_LED_GPIO, GPIO_PIN_TYPE_STD);
+    GPIO_setDirectionMode(BLINKY_LED_GPIO, GPIO_DIR_MODE_OUT);
+    GPIO_writePin(BLINKY_LED_GPIO, 0); // LED off
+
+    GPIO_setPadConfig(GD_EN, GPIO_PIN_TYPE_STD);
+    GPIO_setDirectionMode(GD_EN, GPIO_DIR_MODE_OUT);
+    GPIO_writePin(GD_EN, 0); 
+
+    GPIO_setPadConfig(GD_HS_PWM1, GPIO_PIN_TYPE_STD);
+    GPIO_setDirectionMode(GD_HS_PWM1, GPIO_DIR_MODE_OUT);
+    GPIO_writePin(GD_HS_PWM1, 0); 
+
+    GPIO_setPadConfig(GD_LS_PWM1, GPIO_PIN_TYPE_STD);
+    GPIO_setDirectionMode(GD_LS_PWM1, GPIO_DIR_MODE_OUT);
+    GPIO_writePin(GD_LS_PWM1, 0); 
+
+    GPIO_setPadConfig(GD_HS_PWM2, GPIO_PIN_TYPE_STD);
+    GPIO_setDirectionMode(GD_HS_PWM2, GPIO_DIR_MODE_OUT);
+    GPIO_writePin(GD_HS_PWM2, 0); 
+
+    GPIO_setPadConfig(GD_LS_PWM2, GPIO_PIN_TYPE_STD);
+    GPIO_setDirectionMode(GD_LS_PWM2, GPIO_DIR_MODE_OUT);
+    GPIO_writePin(GD_LS_PWM2, 0); 
+
+    GPIO_setPadConfig(GD_HS_PWM3, GPIO_PIN_TYPE_STD);
+    GPIO_setDirectionMode(GD_HS_PWM3, GPIO_DIR_MODE_OUT);
+    GPIO_writePin(GD_HS_PWM3, 0); 
+
+    GPIO_setPadConfig(GD_LS_PWM3, GPIO_PIN_TYPE_STD);
+    GPIO_setDirectionMode(GD_LS_PWM3, GPIO_DIR_MODE_OUT);
+    GPIO_writePin(GD_LS_PWM3, 0); 
+
+    GPIO_setPadConfig(GD_FLT1, GPIO_PIN_TYPE_STD);
+    GPIO_setDirectionMode(GD_FLT1, GPIO_DIR_MODE_IN);
+
+    GPIO_setPadConfig(GD_FLT2, GPIO_PIN_TYPE_STD);
+    GPIO_setDirectionMode(GD_FLT2, GPIO_DIR_MODE_IN);
+
+    GPIO_setPadConfig(GD_FLT3, GPIO_PIN_TYPE_STD);
+    GPIO_setDirectionMode(GD_FLT3, GPIO_DIR_MODE_IN);
+
+}
 
 void EnableVoltageSen()
 {
@@ -11,16 +60,60 @@ void EnableVoltageSen()
     float voltageDC = 0.0f;
     
 
-    for(int i=0; i<10;i++)
-    {
-        void ADC_TriggerVoltages();
 
-        voltageA = GetVoltageA();
-        voltageB = GetVoltageB();
-        voltageC = GetVoltageC();
-        voltageDC = GetVoltageDC();
+    void ADC_TriggerVoltages();
 
-    }
+    voltageA = GetVoltageA();
+    voltageB = GetVoltageB();
+    voltageC = GetVoltageC();
+    voltageDC = GetVoltageDC();
+
+
     return;
 }
 
+void EnableGateDriver(void)
+{
+    int val1, val2,val3;
+    GD_EN_VAL =!(GD_EN_VAL);
+    
+    
+
+    GPIO_writePin(GD_EN,GD_EN_VAL);
+    
+
+    GPIO_writePin(GD_HS_PWM1,1);
+    GPIO_writePin(GD_LS_PWM1,1);
+
+    GPIO_writePin(GD_HS_PWM2,1);
+    GPIO_writePin(GD_LS_PWM2,1);
+
+    GPIO_writePin(GD_HS_PWM3,1);
+    GPIO_writePin(GD_LS_PWM3,1);
+    
+
+    val1 = GPIO_readPin(GD_FLT1);
+    val2 = GPIO_readPin(GD_FLT2);
+    val3 = GPIO_readPin(GD_FLT3);
+
+    if (val1==1 && val2==1 && val3==1)
+    {
+        GPIO_writePin(BLINKY_LED_GPIO, 0);
+    }
+
+    return;
+}
+
+void EnableCurrentSen()
+{
+    float CurrentA = 0.0f;
+    float CurrentB = 0.0f;
+    float CurrentC = 0.0f;
+
+
+    CurrentA = GetCurrentA();
+    CurrentB = GetCurrentB();
+    CurrentC = GetCurrentC();
+
+    
+}

--- a/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Src/board_test.c
+++ b/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Src/board_test.c
@@ -1,0 +1,26 @@
+#include <stdio.h>
+#include "adc_config.h"
+
+void EnableVoltageSen()
+{
+    HAL_StatusTypeDef ADC_Config_Init();
+    
+    float voltageA = 0.0f;
+    float voltageB = 0.0f;
+    float voltageC = 0.0f;
+    float voltageDC = 0.0f;
+    
+
+    for(int i=0; i<10;i++)
+    {
+        void ADC_TriggerVoltages();
+
+        voltageA = GetVoltageA();
+        voltageB = GetVoltageB();
+        voltageC = GetVoltageC();
+        voltageDC = GetVoltageDC();
+
+    }
+    return;
+}
+

--- a/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Src/control.c
+++ b/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Src/control.c
@@ -1,12 +1,123 @@
 #include "control.h"
+#include <math.h>
 
 
-void InitControl(void)
+void InitPIDControl(pid *pid_var,float set_point,float kp, float ki,float limit, float sampling_time)
 {
+    //Initization to zero
+    pid_var->error = 0.0f;
+    pid_var->integral = 0.0f;
+    pid_var->output = 0.0f;
+
+    //Setup Values
+    pid_var->kp = kp ;
+    pid_var->ki = ki;
+    pid_var->set_point = set_point;
+    pid_var->min_integral = -limit;
+    pid_var->max_integral = limit;
+    pid_var->sampling_time = sampling_time;
+}
+
+void PIDControl(pid *pid_var, float measured_value)
+{
+    
+    pid_var->error = pid_var->set_point - measured_value;             // Calculation Error 
+
+    pid_var->integral += pid_var->error *  pid_var->sampling_time;   
+
+    if (pid_var->integral > pid_var->max_integral)
+    pid_var->integral = pid_var->max_integral;           
+
+    else if (pid_var->integral < pid_var->min_integral)
+    {
+        pid_var->integral = pid_var->min_integral;
+    }
+
+
+    pid_var->output = (pid_var->kp * pid_var->error) + (pid_var->ki * pid_var->integral); // Calculating PID output 
+  
+
     return;
 }
 
-void TaskControl(void)
+cart PolartoCartesian(polar p)
 {
-    return;
+    cart c ={0};
+    c.x = p.r*cosf(p.theta);
+    c.y = p.r*sinf(p.theta);
+    return c ;
 }
+
+polar CartesiantoPolar(cart c)
+{
+    polar p = {0};
+    p.r = sqrtf(c.x * c.x + c.y * c.y);
+    p.theta = atan2f(c.y, c.x);
+
+    return p;
+}
+dq AlphabetaToDq(alphabeta alphabeta_var, float theta)
+{
+    dq dq_var = {0};
+    dq_var.d =  alphabeta_var.alpha * cosf(theta) + alphabeta_var.beta * sinf(theta);
+    dq_var.q = -alphabeta_var.alpha * sinf(theta) + alphabeta_var.beta * cosf(theta);
+    return dq_var;
+
+}
+
+alphabeta DqToAlphabeta(dq dq_var, float theta)
+{
+    alphabeta alphabeta_var = {0};
+    alphabeta_var.alpha = dq_var.d * cosf(theta) - dq_var.q * sinf(theta);
+    alphabeta_var.beta  = dq_var.d * sinf(theta) + dq_var.q * cosf(theta);
+    return alphabeta_var;
+}
+
+
+void InitSogiPll(sogi *sogi_var,float gain, float sampling_time)
+{
+    sogi_var->alpha = 0.0f;
+    sogi_var->beta = 0.0f;
+    sogi_var->k = gain; 
+    sogi_var->sampling_time = sampling_time;
+
+return ;    
+}
+
+void SogiPll(sogi *sogi_var,float input,float omega)
+{
+    sogi_var->err = input*sogi_var->k- sogi_var->alpha;
+    sogi_var->alpha += ((sogi_var->err - sogi_var->beta)*omega)*sogi_var->sampling_time;    //alpha calculation 
+    sogi_var->beta += sogi_var->alpha*omega*sogi_var->sampling_time;                        //beta calculation       
+    return;
+
+}
+
+typedef struct
+{
+    int freq;
+    float sampling_time;
+    float theta;
+    float omega;
+
+}angelgen ;
+
+void InitAngleGen(angelgen *ag_var, int freq, float sampling_time)
+{
+    ag_var->theta = 0;
+    ag_var->omega = 2*PI*freq;
+    ag_var->sampling_time = sampling_time;
+}
+void AngleGen(angelgen *ag_var)
+{
+    
+    ag_var->theta = ag_var->theta + ag_var->omega * ag_var->sampling_time;
+        
+    if (ag_var->theta > 2.0f * PI)
+        ag_var->theta -= 2.0f * PI;
+    if (ag_var->theta < 0.0f)
+        ag_var->theta += 2.0f * PI;
+
+}
+
+

--- a/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Src/control.c
+++ b/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Src/control.c
@@ -1,123 +1,214 @@
+// @file control.c
+// @author Arnold
+// @brief implement control task
+// @version 1.0
+// @date 2026-04-06
+//
+// @copyright Copyright (c) 2026
+
 #include "control.h"
 #include <math.h>
 
-
-void InitPIDControl(pid *pid_var,float set_point,float kp, float ki,float limit, float sampling_time)
+// @brief Initialize PID controller to zero and set gains
+// @param [in,out] pid_var       PID struct to initialize
+// @param [in]     set_point     target reference value
+// @param [in]     kp            proportional gain
+// @param [in]     ki            integral gain
+// @param [in]     limit         integral clamp value, applied as +/- limit
+// @param [in]     sampling_time loop period in seconds
+// @return none
+void InitPIDControl(PidTypeDef *pid_var,float set_point,float kp, float ki,float limit, float sampling_time)
 {
-    //Initization to zero
-    pid_var->error = 0.0f;
-    pid_var->integral = 0.0f;
-    pid_var->output = 0.0f;
+    // Initialize outputs and state to zero
+    pid_var->error         = 0.0f;
+    pid_var->integral      = 0.0f;
+    pid_var->output        = 0.0f;
 
-    //Setup Values
-    pid_var->kp = kp ;
-    pid_var->ki = ki;
-    pid_var->set_point = set_point;
-    pid_var->min_integral = -limit;
-    pid_var->max_integral = limit;
+    // Store gains
+    pid_var->kp            = kp;
+    pid_var->ki            = ki;
+
+    // Store setpoint and timing
+    pid_var->set_point     = set_point;
     pid_var->sampling_time = sampling_time;
+
+    // Apply integral clamp symmetrically around zero
+    pid_var->min_integral  = -limit;
+    pid_var->max_integral  =  limit;
 }
 
-void PIDControl(pid *pid_var, float measured_value)
-{
-    
-    pid_var->error = pid_var->set_point - measured_value;             // Calculation Error 
 
-    pid_var->integral += pid_var->error *  pid_var->sampling_time;   
+// @brief Run one PID cycle, call at fixed sampling_time interval
+// @param [in,out] pid_var         PID struct
+// @param [in]     measured_value  current process measurement
+// @return none
+void PIDControl(PidTypeDef *pid_var, float measured_value)
+{    
+    // Calculate error between target and measured
+    pid_var->error = pid_var->set_point - measured_value;
 
+    // Accumulate error over time — integral term
+    pid_var->integral += pid_var->error * pid_var->sampling_time;
+
+    // Clamp integral to prevent windup
     if (pid_var->integral > pid_var->max_integral)
-    pid_var->integral = pid_var->max_integral;           
-
+    {
+        pid_var->integral = pid_var->max_integral;
+    }
     else if (pid_var->integral < pid_var->min_integral)
     {
         pid_var->integral = pid_var->min_integral;
     }
 
-
-    pid_var->output = (pid_var->kp * pid_var->error) + (pid_var->ki * pid_var->integral); // Calculating PID output 
+    // Sum P and I contributions to produce output
+    pid_var->output = (pid_var->kp * pid_var->error) + (pid_var->ki * pid_var->integral);
   
 
     return;
 }
 
-cart PolartoCartesian(polar p)
+/* -----------------------------------------------------------------------
+ * Coordinate transforms
+ * -------------------------------------------------------------------- */
+
+// @brief Convert polar coordinates to cartesian
+// @param [in] p    polar input (r, theta)
+// @return          cartesian output (x, y)
+CartTypeDef ConvertPolarToCartesian(PolarTypeDef p)
 {
-    cart c ={0};
-    c.x = p.r*cosf(p.theta);
-    c.y = p.r*sinf(p.theta);
+    CartTypeDef c ={0};
+
+    // x = r * cos(theta), y = r * sin(theta)
+    c.x = p.r * cosf(p.theta);
+    c.y = p.r * sinf(p.theta);
     return c ;
 }
 
-polar CartesiantoPolar(cart c)
+// @brief Convert cartesian coordinates to polar
+// @param [in] c    cartesian input (x, y)
+// @return          polar output (r, theta)
+PolarTypeDef ConvertCartesianToPolar(CartTypeDef c)
 {
-    polar p = {0};
+    PolarTypeDef p = {0};
+
+    // magnitude from Pythagoras
     p.r = sqrtf(c.x * c.x + c.y * c.y);
+
+    // angle using four-quadrant arctangent
     p.theta = atan2f(c.y, c.x);
 
     return p;
 }
-dq AlphabetaToDq(alphabeta alphabeta_var, float theta)
+
+
+/* -----------------------------------------------------------------------
+ * Frame transforms
+ * -------------------------------------------------------------------- */
+
+// @brief Park transform — stationary alphabeta frame to rotating dq frame
+// @param [in] alphabeta_var    alphabeta frame input
+// @param [in] theta            rotor electrical angle in radians
+// @return                      dq frame output
+DqTypeDef ConvertAlphabetaToDq(AlphabetaTypeDef alphabeta_var, float theta)
 {
-    dq dq_var = {0};
+    DqTypeDef dq_var = {0};
+
+    
     dq_var.d =  alphabeta_var.alpha * cosf(theta) + alphabeta_var.beta * sinf(theta);
     dq_var.q = -alphabeta_var.alpha * sinf(theta) + alphabeta_var.beta * cosf(theta);
-    return dq_var;
 
+    return dq_var;
 }
 
-alphabeta DqToAlphabeta(dq dq_var, float theta)
+// @brief Inverse Park transform — rotating dq frame to stationary alphabeta frame
+// @param [in] dq_var   dq frame input
+// @param [in] theta    rotor electrical angle in radians
+// @return              alphabeta frame output
+AlphabetaTypeDef ConvertDqToAlphabeta(DqTypeDef dq_var, float theta)
 {
-    alphabeta alphabeta_var = {0};
+    AlphabetaTypeDef alphabeta_var = {0};
+
+    
     alphabeta_var.alpha = dq_var.d * cosf(theta) - dq_var.q * sinf(theta);
     alphabeta_var.beta  = dq_var.d * sinf(theta) + dq_var.q * cosf(theta);
+
     return alphabeta_var;
 }
 
+/* -----------------------------------------------------------------------
+ * SOGI
+ * -------------------------------------------------------------------- */
 
-void InitSogiPll(sogi *sogi_var,float gain, float sampling_time)
+// @brief Initialize SOGI struct
+// @param [in,out] sogi_var      SOGI struct to initialize
+// @param [in]     gain          damping gain k, typically sqrt(2) = 1.414
+// @param [in]     sampling_time loop period in seconds
+// @return none
+void InitSogi(SogiTypeDef *sogi_var,float gain, float sampling_time)
 {
-    sogi_var->alpha = 0.0f;
-    sogi_var->beta = 0.0f;
-    sogi_var->k = gain; 
-    sogi_var->sampling_time = sampling_time;
+    // Initialize integrator states to zero
+    sogi_var->alpha         = 0.0f;
+    sogi_var->beta          = 0.0f;
 
-return ;    
+    // Store damping gain and timing
+    sogi_var->k             = gain;
+    sogi_var->sampling_time = sampling_time;
+    return ;    
 }
 
-void SogiPll(sogi *sogi_var,float input,float omega)
+// @brief Run one SOGI cycle, generates quadrature alpha and beta signals
+// @param [in,out] sogi_var  SOGI struct
+// @param [in]     input     single phase AC input sample
+// @param [in]     omega     angular frequency in rad/s
+// @return none
+void RunSogi(SogiTypeDef *sogi_var,float input,float omega)
 {
-    sogi_var->err = input*sogi_var->k- sogi_var->alpha;
-    sogi_var->alpha += ((sogi_var->err - sogi_var->beta)*omega)*sogi_var->sampling_time;    //alpha calculation 
-    sogi_var->beta += sogi_var->alpha*omega*sogi_var->sampling_time;                        //beta calculation       
+    float err = (input * sogi_var->k)- sogi_var->alpha;
+    // First integrator — alpha tracks the input in-phase
+    sogi_var->alpha += ((err - sogi_var->beta)*omega)*sogi_var->sampling_time;    
+     // Second integrator — beta is 90 degrees shifted version of alpha
+    sogi_var->beta += sogi_var->alpha*omega*sogi_var->sampling_time;                      
     return;
 
 }
 
-typedef struct
-{
-    int freq;
-    float sampling_time;
-    float theta;
-    float omega;
+/* -----------------------------------------------------------------------
+ * Angle generation
+ * -------------------------------------------------------------------- */
 
-}angelgen ;
-
-void InitAngleGen(angelgen *ag_var, int freq, float sampling_time)
+// @brief Initialize angle generator
+// @param [in,out] ag_var        angle generator struct to initialize
+// @param [in]     freq          fixed frequency in Hz
+// @param [in]     sampling_time loop period in seconds
+// @return none
+void InitAngleGen(AngleGenTypeDef *ag_var, int freq, float sampling_time)
 {
-    ag_var->theta = 0;
-    ag_var->omega = 2*PI*freq;
+    // Start angle at zero
+    ag_var->theta         = 0.0f;
+
+    // Convert frequency in Hz to angular frequency in rad/s
+    ag_var->omega         = 2.0f * PI * freq;
+
     ag_var->sampling_time = sampling_time;
 }
-void AngleGen(angelgen *ag_var)
-{
-    
-    ag_var->theta = ag_var->theta + ag_var->omega * ag_var->sampling_time;
-        
-    if (ag_var->theta > 2.0f * PI)
-        ag_var->theta -= 2.0f * PI;
-    if (ag_var->theta < 0.0f)
-        ag_var->theta += 2.0f * PI;
 
+// @brief Run one angle generation cycle, integrates omega to produce theta
+// @param [in,out] ag_var    angle generator struct
+// @return none
+void GenerateAngle(AngleGenTypeDef *ag_var)
+{
+    // Integrate angular frequency to get angle
+    ag_var->theta += ag_var->omega * ag_var->sampling_time;
+
+    // Wrap angle to keep within 0 to 2*pi
+    if (ag_var->theta > TWO_PI)
+    {
+        ag_var->theta -= TWO_PI;
+    }
+    if (ag_var->theta < 0.0f)
+    {
+        ag_var->theta += TWO_PI;
+    }
 }
 
 

--- a/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Src/control_math.c
+++ b/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Src/control_math.c
@@ -1,4 +1,4 @@
-// @file control.c
+// @file control_math.c
 // @author Arnold
 // @brief implement control task
 // @version 1.0
@@ -6,44 +6,45 @@
 //
 // @copyright Copyright (c) 2026
 
-#include "control.h"
+#include "control_math.h"
 #include <math.h>
 
 // @brief Initialize PID controller to zero and set gains
 // @param [in,out] pid_var       PID struct to initialize
-// @param [in]     set_point     target reference value
 // @param [in]     kp            proportional gain
 // @param [in]     ki            integral gain
 // @param [in]     limit         integral clamp value, applied as +/- limit
 // @param [in]     sampling_time loop period in seconds
 // @return none
-void InitPIDControl(PidTypeDef *pid_var,float set_point,float kp, float ki,float limit, float sampling_time)
+void InitPiControl(PiTypeDef *pid_var,float kp, float ki,float limit, float sampling_time)
 {
     // Initialize outputs and state to zero
     pid_var->error         = 0.0f;
     pid_var->integral      = 0.0f;
     pid_var->output        = 0.0f;
+    pid_var->set_point     = 0.0f;
 
     // Store gains
     pid_var->kp            = kp;
     pid_var->ki            = ki;
 
     // Store setpoint and timing
-    pid_var->set_point     = set_point;
+    
     pid_var->sampling_time = sampling_time;
 
     // Apply integral clamp symmetrically around zero
-    pid_var->min_integral  = -limit;
-    pid_var->max_integral  =  limit;
+    pid_var->limit  = limit;
 }
 
 
 // @brief Run one PID cycle, call at fixed sampling_time interval
 // @param [in,out] pid_var         PID struct
+// @param [in]     set_point        target reference value
 // @param [in]     measured_value  current process measurement
 // @return none
-void PIDControl(PidTypeDef *pid_var, float measured_value)
+void RunPiControl(PiTypeDef *pid_var, float set_point, float measured_value)
 {    
+    pid_var->set_point     = set_point;
     // Calculate error between target and measured
     pid_var->error = pid_var->set_point - measured_value;
 
@@ -51,13 +52,13 @@ void PIDControl(PidTypeDef *pid_var, float measured_value)
     pid_var->integral += pid_var->error * pid_var->sampling_time;
 
     // Clamp integral to prevent windup
-    if (pid_var->integral > pid_var->max_integral)
+    if (pid_var->integral > pid_var->limit)
     {
-        pid_var->integral = pid_var->max_integral;
+        pid_var->integral = pid_var->limit;
     }
-    else if (pid_var->integral < pid_var->min_integral)
+    else if (pid_var->integral < -(pid_var->limit))
     {
-        pid_var->integral = pid_var->min_integral;
+        pid_var->integral = -(pid_var->limit);
     }
 
     // Sum P and I contributions to produce output
@@ -74,7 +75,7 @@ void PIDControl(PidTypeDef *pid_var, float measured_value)
 // @brief Convert polar coordinates to cartesian
 // @param [in] p    polar input (r, theta)
 // @return          cartesian output (x, y)
-CartTypeDef ConvertPolarToCartesian(PolarTypeDef p)
+CartTypeDef PolarToCartesian(PolarTypeDef p)
 {
     CartTypeDef c ={0};
 
@@ -87,7 +88,7 @@ CartTypeDef ConvertPolarToCartesian(PolarTypeDef p)
 // @brief Convert cartesian coordinates to polar
 // @param [in] c    cartesian input (x, y)
 // @return          polar output (r, theta)
-PolarTypeDef ConvertCartesianToPolar(CartTypeDef c)
+PolarTypeDef CartesianToPolar(CartTypeDef c)
 {
     PolarTypeDef p = {0};
 
@@ -109,7 +110,7 @@ PolarTypeDef ConvertCartesianToPolar(CartTypeDef c)
 // @param [in] alphabeta_var    alphabeta frame input
 // @param [in] theta            rotor electrical angle in radians
 // @return                      dq frame output
-DqTypeDef ConvertAlphabetaToDq(AlphabetaTypeDef alphabeta_var, float theta)
+DqTypeDef ConvertAlphabetaToDq(AlphaBetaTypeDef alphabeta_var, float theta)
 {
     DqTypeDef dq_var = {0};
 
@@ -124,9 +125,9 @@ DqTypeDef ConvertAlphabetaToDq(AlphabetaTypeDef alphabeta_var, float theta)
 // @param [in] dq_var   dq frame input
 // @param [in] theta    rotor electrical angle in radians
 // @return              alphabeta frame output
-AlphabetaTypeDef ConvertDqToAlphabeta(DqTypeDef dq_var, float theta)
+AlphaBetaTypeDef ConvertDqToAlphabeta(DqTypeDef dq_var, float theta)
 {
-    AlphabetaTypeDef alphabeta_var = {0};
+    AlphaBetaTypeDef alphabeta_var = {0};
 
     
     alphabeta_var.alpha = dq_var.d * cosf(theta) - dq_var.q * sinf(theta);

--- a/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Src/main.c
+++ b/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Src/main.c
@@ -5,6 +5,7 @@
 #include "state_machine.h"
 #include "task_scheduler.h"
 #include "math.h"
+#include "board_test.h"
 
 #define BLINKY_LED_GPIO    31
 
@@ -78,5 +79,6 @@ void main(void)
     CreateTask(CreateSineWaveTest, 10000);
     //CreateTask(SendUartTest, 300000);
     LoopTaskScheduler();
+    EnableVoltageSen();
 }
 

--- a/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Src/main.c
+++ b/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Src/main.c
@@ -7,7 +7,7 @@
 #include "math.h"
 #include "board_test.h"
 
-#define BLINKY_LED_GPIO    31
+
 
 void ToggleLED(void)
 {
@@ -54,7 +54,7 @@ void main(void)
     GPIO_setPadConfig(BLINKY_LED_GPIO, GPIO_PIN_TYPE_STD);
     GPIO_setDirectionMode(BLINKY_LED_GPIO, GPIO_DIR_MODE_OUT);
     GPIO_writePin(BLINKY_LED_GPIO, 0); // LED off
-
+    
 
     Interrupt_initModule();
     Interrupt_initVectorTable();
@@ -69,13 +69,19 @@ void main(void)
 
     bspInitCpuTimers();
     bspInitSCI();
-
+    InitGateDriverTest();
     EINT;
     ERTM;
     InitStateMachine();
     InitTaskScheduler();
 
-    CreateTask(ToggleLED, 2);
+   //CreateTask(ToggleLED, 2);
+
+    CreateTask(EnableGateDriver,1);
+    CreateTask(EnableVoltageSen,1);
+   
+
+    
     CreateTask(CreateSineWaveTest, 10000);
     //CreateTask(SendUartTest, 300000);
     LoopTaskScheduler();

--- a/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Src/state_machine.c
+++ b/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Src/state_machine.c
@@ -1,6 +1,9 @@
 #include "state_machine.h"
+#include "global_defines.h"
+#include "adc_config.h"
 
 StateMachineTypeDef  state_machine_handle;
+uint16_t __inner_interleaved_mode_switch = 0;
 
 #pragma CODE_SECTION(TaskStateMachine, ".TI.ramfunc");
 
@@ -9,11 +12,154 @@ void InitStateMachine(void)
     state_machine_handle = STATE_INIT;
 }
 
+static inline void CalculateAndInitPI(PiTypeDef *pid_var, float32_t L1, float32_t R1, float32_t tr, float32_t ts)
+{
+    float32_t _kp = L1 * log(9.0f) / tr;
+    float32_t _ki = R1 * log(9.0f) / tr;
+    float32_t _limit = 1000.0f; // need to revise
+    InitPiControl(pid_var, _kp, _ki, _limit, ts);
+}
+
+static inline void InitBlocks(void)
+{
+    control_params.ts_us = TS_US;
+    control_params.interleaved_mode_switch = 0; //default: non-interleaved
+    control_params.output_enabled = 0; //default: output disabled
+    control_params.current_feedback_amps = 0.0f;
+    control_params.k_current_feedback = CURRENT_FB_GAIN;
+    control_params.omega_rad = 0.0f;
+    control_params.sin_omega = 0.0f;
+    control_params.cos_omega = 0.0f;
+    control_params.idq_meas_amps.d = 0.0f;
+    control_params.idq_meas_amps.q = 0.0f;
+    control_params.idq_ref_amps.d = ID_REF_AMPS;
+    control_params.idq_ref_amps.q = IQ_REF_AMPS;
+    control_params.pi_output_cart.x = 0.0f;
+    control_params.pi_output_cart.y = 0.0f;
+    control_params.pi_output_polar.r = 0.0f;
+    control_params.pi_output_polar.theta = 0.0f;
+    control_params.reset = 0;
+
+    CalculateAndInitPI(&control_params.pi_id, L1_UH, R1_OHM, TR, TS_US);
+    CalculateAndInitPI(&control_params.pi_iq, L1_UH, R1_OHM, TR, TS_US);
+
+    InitAngleGen(&control_params.angle_generation, AC_FREQ, TS_US);
+    InitSogi(&control_params.current_sogi, SOGI_GAIN, TS_US);
+}
+
+static inline uint16_t OverCurrentCheck(void)
+{
+    float32_t _ia = GetCurrentA();
+    float32_t _ib = GetCurrentB();
+    float32_t _ic = GetCurrentC();
+    if(_ia > MAX_PHASE_CURRENT_AMPS || _ib > MAX_PHASE_CURRENT_AMPS || _ic > MAX_PHASE_CURRENT_AMPS)
+    {
+        return false;
+    }
+    return true;
+}
+
+static inline void Clamp(PolarTypeDef *polar, float32_t limit)
+{
+    if(polar->r > limit)
+    {
+        polar->r = limit;
+    }
+    if(polar->r < -limit)
+    {
+        polar->r = -limit;
+    }
+}
+
+static inline void DisableDrivers(void)
+{
+    GPIO_writePin(25, 0);
+}
+
+static inline uint16_t CheckResetEnabled(void)
+{
+    if(control_params.reset)
+    {
+        control_params.reset = 0;
+        return 1;
+    }
+    return 0;
+}
+
 void TaskStateMachine(void)
 {
     switch (state_machine_handle) 
     {
         case STATE_INIT:
-        break;
+            InitBlocks();
+            HAL_StatusTypeDef fb = ADC_Config_Init();
+            if(fb != HAL_OK)
+            {
+                state_machine_handle = STATE_ERROR;
+            }
+            state_machine_handle = STATE_IDLE;
+            break;
+        case STATE_IDLE:
+            if(control_params.output_enabled)
+            {
+                state_machine_handle = STATE_RUNNING;
+            }
+            break;
+        case STATE_RUNNING:
+            GenerateAngle(&control_params.angle_generation);
+            if(!OverCurrentCheck())
+            {
+                state_machine_handle = STATE_OVER_CURRENT;
+                break;
+            }
+            if(control_params.interleaved_mode_switch != __inner_interleaved_mode_switch) // if this variable chenged by outside
+            {
+                state_machine_handle = STATE_DISCHARGING;//we need to restart whole thing
+                __inner_interleaved_mode_switch = control_params.interleaved_mode_switch;
+                break;
+            }
+            if(__inner_interleaved_mode_switch)
+            {
+                //interleaved
+            }
+            else
+            {
+                //non-interleaved
+            }
+            //Run sogi
+            float32_t i_fb = GetCurrentC();
+            RunSogi(&control_params.current_sogi, i_fb, control_params.angle_generation.omega);
+            control_params.current_ab_amps.alpha = control_params.current_sogi.alpha;
+            control_params.current_ab_amps.beta = control_params.current_sogi.beta;
+            //Run AB => DQ
+            control_params.idq_meas_amps = ConvertAlphabetaToDq(control_params.current_ab_amps, control_params.angle_generation.theta);
+            RunPiControl(&control_params.pi_id, control_params.idq_ref_amps.d, control_params.idq_meas_amps.d);
+            RunPiControl(&control_params.pi_iq, control_params.idq_ref_amps.q, control_params.idq_meas_amps.q);
+            //Convert to polar
+            control_params.pi_output_cart.x = control_params.pi_id.output; //D axis aligned with x
+            control_params.pi_output_cart.y = control_params.pi_iq.output;
+            control_params.pi_output_polar = CartesianToPolar(control_params.pi_output_cart);
+            Clamp(&control_params.pi_output_polar, VDC / 2);
+            //Convert back to xy
+            control_params.pi_output_cart = PolarToCartesian(control_params.pi_output_polar);
+            control_params.idq_output_amps.d = control_params.pi_output_cart.x;
+            control_params.idq_output_amps.q = control_params.pi_output_cart.y;
+            //DQ to AB
+            control_params.output_ab = ConvertDqToAlphabeta(control_params.idq_output_amps, control_params.angle_generation.theta);
+            //normalization
+            control_params.output_duty = control_params.output_ab.alpha / (VDC / 2);
+            //SetDuty(3, control_params.output_duty);
+            break;
+        case STATE_DISCHARGING:
+            //DisablePWM(1);
+            break;
+        case STATE_STOP:
+            break;
+        case STATE_ERROR:
+            break;
+        case STATE_OVER_CURRENT:
+            break;
+        default:
+            break;
     }
 }

--- a/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Src/task_scheduler.c
+++ b/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Src/task_scheduler.c
@@ -122,6 +122,7 @@ HAL_StatusTypeDef CreateTask(void (*task_handler)(void), uint32_t hertz)
         }
         return HAL_OK;
     }
+    return HAL_ERROR;
 }
 
 void TaskIdle(void)

--- a/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Src/viewer.c
+++ b/firmware/ga2o3-ws/ga2o3-apd/PROJ/App/Src/viewer.c
@@ -1,14 +1,18 @@
 #include "viewer.h"
 #include "stdint.h"
 #include "device.h"
+#include "bsp_cputimer.h"
 
 #pragma CODE_SECTION(serialDriverSendData, ".TI.ramfunc");
+uint32_t _tim;
 
 void serialDriverSendData(uint16_t* buf, uint16_t size)
 {
+    _tim = bspGetCpuTimerTicks();
     for(uint16_t i = 0; i < size; i++)
     {
         SCI_writeCharBlockingFIFO(SCIA_BASE, buf[i]);
     }
+    _tim = bspGetCpuTimerTicks() - _tim;
     //SCI_writeCharArray(SCIA_BASE, buf, size);
 }

--- a/firmware/ga2o3-ws/ga2o3-apd/PROJ/Libs/Bsp/Src/bsp_sci.c
+++ b/firmware/ga2o3-ws/ga2o3-apd/PROJ/Libs/Bsp/Src/bsp_sci.c
@@ -3,10 +3,12 @@
 #include "device.h"
 #include "bsp_hal.h"
 #include "serialDriver.h"
+#include "bsp_cputimer.h"
 
 #pragma CODE_SECTION(SciaTxFIFOIsr, ".TI.ramfunc");
 #pragma CODE_SECTION(SciaRxFIFOIsr, ".TI.ramfunc");
-
+uint32_t _tmp;
+uint32_t _t;
 __interrupt void SciaTxFIFOIsr(void)
 {
     SCI_clearInterruptStatus(SCIA_BASE, SCI_INT_TXFF);
@@ -15,12 +17,15 @@ __interrupt void SciaTxFIFOIsr(void)
 
 __interrupt void SciaRxFIFOIsr(void)
 {
+    _tmp = bspGetCpuTimerTicks();
     char rxChar = SCI_readCharBlockingFIFO(SCIA_BASE);
     SCI_clearOverflowStatus(SCIA_BASE);
     SCI_clearInterruptStatus(SCIA_BASE, SCI_INT_RXFF);
 
     Interrupt_clearACKGroup(INTERRUPT_ACK_GROUP9);
+    
     serialDriverReceiveByte(rxChar);
+    _t = bspGetCpuTimerTicks() - _tmp;
 }
 
 
@@ -49,7 +54,7 @@ HAL_StatusTypeDef bspInitSCI(void)
     //
     // 8 char bits, 1 stop bit, no parity. Baud rate 115200.
     //
-    SCI_setConfig(SCIA_BASE, DEVICE_LSPCLK_FREQ, 115200, (SCI_CONFIG_WLEN_8 |
+    SCI_setConfig(SCIA_BASE, DEVICE_LSPCLK_FREQ, 2000000, (SCI_CONFIG_WLEN_8 |
                                                         SCI_CONFIG_STOP_ONE |
                                                         SCI_CONFIG_PAR_NONE));
 


### PR DESCRIPTION
## Summary
Implements control.h and control.c for the control task module.

## Changes
- Added PidTypeDef struct and PID controller (InitPIDControl, PIDControl)
    - Proportional and integral terms
    - Integral anti-windup clamp via min/max limit

- Added coordinate transform functions
    - ConvertPolarToCartesian
    - ConvertCartesianToPolar

- Added frame transform functions
    - ConvertAlphabetaToDq  (Park transform)
    - ConvertDqToAlphabeta  (Inverse Park transform)

- Added SogiTypeDef struct and SOGI functions (InitSogi, RunSogi)
    - Generates quadrature alpha and beta from single phase input
    - Damping gain k, typically sqrt(2) = 1.414

- Added AngleGenTypeDef struct and angle generation (InitAngleGen, GenerateAngle)
    - Fixed frequency system
    - Integrates omega to produce theta
    - Wraps angle to 0 to 2*pi

## Notes
- System frequency is fixed, no PLL feedback loop required
- PI only, no D term in PID controller


## Testing
- [ ] PID output verified against manual calculation
- [ ] SOGI alpha and beta verified 90 degrees apart after settling
- [ ] Angle wraps correctly at 2*pi boundary
- [ ] Coordinate and frame transforms verified against known values

## Related Issues
- Closes #